### PR TITLE
Ignore mousedown event if emitted on scrollbar

### DIFF
--- a/js/TouchScroll.js
+++ b/js/TouchScroll.js
@@ -109,7 +109,8 @@ var TouchScroll = function () {
          */
         onMouseDown: function (e) {
             if (this.drag === false || this.options.wait === false) {
-                this.drag = true;
+                // ignore mousedown event if emitted on scrollbar
+                this.drag = e.offsetX <= e.target.clientWidth && e.offsetY <= e.target.clientHeight;
                 this.cancelEvent(e);
                 this.startx = e.clientX + this.el.scrollLeft;
                 this.starty = e.clientY + this.el.scrollTop;


### PR DESCRIPTION
In my usage of touch-scroll where I pan a giant table's content, I chose not to hide the scrollbars as they still serve their purpose for concise navigation and as indicators as to how much more data there is to view.

While testing in IE I noticed that the scrollbar was emitting mousedown events to touch-scroll's mousedown handler and thus you couldn't navigate using the scrollbar.  While not a problem when the scrollbar is hidden, it obviously becomes an issue when it is not.  

I don't know if you would consider this out of scope because you hide the scrollbar by default, but this fix should help correct the expected behavior and continue working well with others that didn't exhibit it.

Thanks!